### PR TITLE
[Refactor] 30개 추가 -> 현위치 기반으로 변경 (#31)

### DIFF
--- a/NiCarNaeCar/NiCarNaeCar/Screen/Main/Controller/MainViewController.swift
+++ b/NiCarNaeCar/NiCarNaeCar/Screen/Main/Controller/MainViewController.swift
@@ -142,6 +142,28 @@ final class MainViewController: BaseViewController {
           }
         }
     }
+    
+    private func convertLocationToSublocality(_ location: CLLocation) -> String {
+        var subLocality = ""
+        
+        let geocoder = CLGeocoder()
+        let locale = Locale(identifier: "Ko-kr")
+        
+        geocoder.reverseGeocodeLocation(location, preferredLocale: locale, completionHandler: {(placemarks, error) in
+            if let address: [CLPlacemark] = placemarks {
+                if let result: String = address.last?.subLocality {
+                    print(result)
+                    subLocality = result
+                }
+            }
+        })
+        
+        return subLocality
+    }
+    
+    private func convertSublocalityToLocality(_ location: CLLocation) -> String {
+        return ""
+    }
 }
 
 // MARK: - MapView Protocol
@@ -255,6 +277,8 @@ extension MainViewController: CLLocationManagerDelegate {
             
             setRegion(center: coordinate, meters: 1200)
             setAnnotation(center: coordinate, title: Constant.Annotation.currentLocationTitle)
+            
+            convertLocationToSublocality(CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude))
         }
         locationManager.stopUpdatingLocation()
     }

--- a/NiCarNaeCar/NiCarNaeCar/Screen/Main/View/MainView.swift
+++ b/NiCarNaeCar/NiCarNaeCar/Screen/Main/View/MainView.swift
@@ -19,7 +19,6 @@ protocol MainViewDelegate: MainViewController {
     
     func touchUpSearchBarButton()
     func touchUpRefreshButton()
-    func touchUpAddButton()
     func touchUpCurrentLocationButton()
     
 }
@@ -64,11 +63,6 @@ final class MainView: BaseView {
         $0.addTarget(self, action: #selector(touchUpRefreshButton), for: .touchUpInside)
     }
     
-    private lazy var addButton = NDSFloatingButton().then {
-        $0.text = "+30"
-        $0.addTarget(self, action: #selector(touchUpAddButton), for: .touchUpInside)
-    }
-    
     private lazy var currentLocationButton = NDSFloatingButton().then {
         $0.image = R.Image.btnLocation
         $0.addTarget(self, action: #selector(touchUpCurrentLocationButton), for: .touchUpInside)
@@ -87,7 +81,7 @@ final class MainView: BaseView {
     
     override func setLayout() {
         addSubviews(navigationBar, mapView)
-        mapView.addSubviews(searchBarButton, currentLocationButton, addButton, refreshButton)
+        mapView.addSubviews(searchBarButton, currentLocationButton, refreshButton)
         
         navigationBar.snp.makeConstraints { make in
             make.top.leading.trailing.equalTo(self.safeAreaLayoutGuide)
@@ -129,15 +123,10 @@ final class MainView: BaseView {
             make.bottom.equalToSuperview().inset(40)
             make.trailing.equalToSuperview().inset(Metric.margin)
         }
-        
-        addButton.snp.makeConstraints { make in
-            make.bottom.equalTo(currentLocationButton.snp.top).offset(-15)
-            make.trailing.equalToSuperview().inset(Metric.margin)
-        }
     }
     
     private func configureButton() {
-        [refreshButton, searchBarButton, currentLocationButton, addButton].forEach { button in
+        [refreshButton, searchBarButton, currentLocationButton].forEach { button in
             button.layer.applySketchShadow(color: R.Color.gray100, alpha: 0.3, x: 0, y: 4, blur: 10, spread: 0)
         }
     }
@@ -150,10 +139,6 @@ final class MainView: BaseView {
     
     @objc func touchUpRefreshButton() {
         buttonDelegate?.touchUpRefreshButton()
-    }
-    
-    @objc func touchUpAddButton() {
-        buttonDelegate?.touchUpAddButton()
     }
     
     @objc func touchUpCurrentLocationButton() {


### PR DESCRIPTION
## 작업한 내용 
- 30개 추가 버튼 삭제 
- 현위치의 '동' 정보를 바탕으로 1~1870개의 정보 중 같은 동네의 정보로 업데이트
- 자치구/동 열거형으로 관리 (처음 진입 시에는 동으로 검색, 자치구 검색 이후에는 구로 검색)
- 네트워크 중복되는 코드 개선 