### PR TITLE
[#42] Segmented Control/Map Configuration 구현

### DIFF
--- a/NiCarNaeCar/NiCarNaeCar.xcodeproj/project.pbxproj
+++ b/NiCarNaeCar/NiCarNaeCar.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		925F7E2E28D85FB000F6C9DA /* SearchType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925F7E2D28D85FB000F6C9DA /* SearchType.swift */; };
 		925F7E3028D87D5400F6C9DA /* DefaultAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925F7E2F28D87D5400F6C9DA /* DefaultAnnotationView.swift */; };
 		925F7E5428DA259900F6C9DA /* NetworkConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925F7E5328DA259900F6C9DA /* NetworkConnectionStatus.swift */; };
+		925F7E6028DA8B7500F6C9DA /* MapType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925F7E5F28DA8B7500F6C9DA /* MapType.swift */; };
 		9267150E28D07AF2002DCDB9 /* NDSGradientPathRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9267150D28D07AF2002DCDB9 /* NDSGradientPathRenderer.swift */; };
 		926DE44928CAD47D0083123F /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926DE44828CAD47D0083123F /* BackButton.swift */; };
 		926DE44B28CAD4850083123F /* CloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926DE44A28CAD4850083123F /* CloseButton.swift */; };
@@ -153,6 +154,7 @@
 		925F7E2D28D85FB000F6C9DA /* SearchType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchType.swift; sourceTree = "<group>"; };
 		925F7E2F28D87D5400F6C9DA /* DefaultAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAnnotationView.swift; sourceTree = "<group>"; };
 		925F7E5328DA259900F6C9DA /* NetworkConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectionStatus.swift; sourceTree = "<group>"; };
+		925F7E5F28DA8B7500F6C9DA /* MapType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapType.swift; sourceTree = "<group>"; };
 		9267150D28D07AF2002DCDB9 /* NDSGradientPathRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NDSGradientPathRenderer.swift; sourceTree = "<group>"; };
 		926DE44828CAD47D0083123F /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		926DE44A28CAD4850083123F /* CloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseButton.swift; sourceTree = "<group>"; };
@@ -422,6 +424,7 @@
 				9277205E28CF46D200163925 /* CarType.swift */,
 				92BA475A28D45CBB003B973A /* LocalityType.swift */,
 				925F7E2D28D85FB000F6C9DA /* SearchType.swift */,
+				925F7E5F28DA8B7500F6C9DA /* MapType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -776,6 +779,7 @@
 				92BA475B28D45CBB003B973A /* LocalityType.swift in Sources */,
 				926DE48D28CAFC5E0083123F /* URLConstant.swift in Sources */,
 				927404AF28CCACAC0074FBEB /* OnboardingSheetViewController.swift in Sources */,
+				925F7E6028DA8B7500F6C9DA /* MapType.swift in Sources */,
 				926DE49328CB223B0083123F /* CarList.swift in Sources */,
 				9267150E28D07AF2002DCDB9 /* NDSGradientPathRenderer.swift in Sources */,
 				92BA475528D421B9003B973A /* MainSearchViewController.swift in Sources */,

--- a/NiCarNaeCar/NiCarNaeCar/Screen/Main/Model/MapType.swift
+++ b/NiCarNaeCar/NiCarNaeCar/Screen/Main/Model/MapType.swift
@@ -1,0 +1,13 @@
+//
+//  MapType.swift
+//  NiCarNaeCar
+//
+//  Created by 소연 on 2022/09/21.
+//
+
+import Foundation
+
+enum MapType: Int {
+    case standard = 0
+    case hybrid = 1
+}

--- a/NiCarNaeCar/NiCarNaeCar/Screen/Main/View/Map/MainMapView.swift
+++ b/NiCarNaeCar/NiCarNaeCar/Screen/Main/View/Map/MainMapView.swift
@@ -54,6 +54,12 @@ final class MainMapView: BaseView {
         $0.addTarget(self, action: #selector(touchUpCurrentLocationButton), for: .touchUpInside)
     }
     
+    private lazy var segmentedControl = UISegmentedControl(items: ["standard", "hybrid"]).then {
+        $0.backgroundColor = R.Color.gray400
+        $0.addTarget(self, action: #selector(didChangeValue(segment:)), for: .valueChanged)
+        $0.selectedSegmentIndex = 0
+    }
+    
     // MARK: - Property
     
     weak var buttonDelegate: MainMapViewDelegate?
@@ -67,7 +73,7 @@ final class MainMapView: BaseView {
     
     override func setLayout() {
         addSubviews(navigationBar, mapView)
-        mapView.addSubviews(currentLocationButton)
+        mapView.addSubviews(segmentedControl, currentLocationButton)
         
         navigationBar.snp.makeConstraints { make in
             make.top.leading.trailing.equalTo(self.safeAreaLayoutGuide)
@@ -98,6 +104,12 @@ final class MainMapView: BaseView {
             make.leading.trailing.bottom.equalToSuperview()
         }
         
+        segmentedControl.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(12)
+            make.leading.trailing.equalToSuperview().inset(Metric.margin)
+            make.height.equalTo(35)
+        }
+        
         currentLocationButton.snp.makeConstraints { make in
             make.bottom.equalToSuperview().inset(60)
             make.trailing.equalToSuperview().inset(Metric.margin)
@@ -120,5 +132,23 @@ final class MainMapView: BaseView {
     
     @objc func touchUpSettingButton() {
         buttonDelegate?.touchUpSettingButton()
+    }
+    
+    @objc private func didChangeValue(segment: UISegmentedControl) {
+        if segment.selectedSegmentIndex == 0 {
+            if #available(iOS 16.0, *) {
+                let standard = MKStandardMapConfiguration(elevationStyle: .realistic)
+                mapView.preferredConfiguration = standard
+            } else {
+                mapView.mapType = .standard
+            }
+        } else if segment.selectedSegmentIndex == 1 {
+            if #available(iOS 16.0, *) {
+                let configuration = MKHybridMapConfiguration(elevationStyle: .realistic)
+                mapView.preferredConfiguration = configuration
+            } else {
+                mapView.mapType = .hybrid
+            }
+        } 
     }
 }


### PR DESCRIPTION
## UI
- UISegmented Control을 사용해서 지도 테마/타입 변경 버튼 구현
- **초기화시, items 배열까지 선언 (ex, `private lazy var segmentedControl = UISegmentedControl(items: ["standard", "hybrid"])`)**

## Feature
- Segmented SelectedIndex를 통해서 지도의 테마/타입 변경
- 기존의 mapView.maptype의 경우 버전이 올라가면서 deprecated 되므로 -> 16이상부터는 MKStandardMapConfiguration / MKHybridMapConfiguration로 테마 설정 

## Branch
closes #42 