### PR TITLE
[#50] 쏘카/그린카 앱스토어 리다이렉션 구현

### DIFF
--- a/NiCarNaeCar/NiCarNaeCar/Network/Base/URLConstant.swift
+++ b/NiCarNaeCar/NiCarNaeCar/Network/Base/URLConstant.swift
@@ -12,3 +12,8 @@ struct URLConstant {
     
     static let NotionURL = "https://receptive-humidity-bf2.notion.site/f48a8b496a484bcaa4191a8128683c58"
 }
+
+extension URLConstant {
+    static let SocarURL = "https://apps.apple.com/kr/app/%EC%8F%98%EC%B9%B4-1%EB%93%B1-%EC%B9%B4%EC%85%B0%EC%96%B4%EB%A7%81/id515173864"
+    static let GreencarURL = "https://apps.apple.com/kr/app/%EA%B7%B8%EB%A6%B0%EC%B9%B4-%EC%9D%B4%EB%8F%99%EC%9D%84-%EC%83%88%EB%A1%9C-%EA%B7%B8%EB%A6%AC%EB%8B%A4/id457792991"
+}

--- a/NiCarNaeCar/NiCarNaeCar/Screen/Detail/Controller/DetailViewController.swift
+++ b/NiCarNaeCar/NiCarNaeCar/Screen/Detail/Controller/DetailViewController.swift
@@ -112,8 +112,19 @@ extension DetailViewController: DetailViewDelegate {
                 print("링크 주소 : \(url)")
             }
         } else {
-            presentAlert(title: "\(brandType.brandNameKR) 앱을 설치해주세요")
-            print("링크 주소 : \(url)")
+            presentAlert(title: "\(brandType.brandNameKR) 앱을 설치해주세요") { _ in
+                self.openURLByBrandType(self.brandType)
+            }
+        }
+    }
+    
+    private func openURLByBrandType(_ brandType: BrandType) {
+        var appStoreURL = brandType == .socar ? URLConstant.SocarURL : URLConstant.GreencarURL
+        
+        if let openApp = URL(string: appStoreURL), UIApplication.shared.canOpenURL(openApp) {
+            if #available(iOS 10.0, *) {
+                UIApplication.shared.open(openApp, options: [:], completionHandler: nil)
+            }
         }
     }
 }


### PR DESCRIPTION
## 작업 내용 
쏘카/그린카가 디바이스에 설치 되어 있지 않았을 때, alert 창을 띄워준 다음, 앱스토어로 이동하여 설치할 수 있도록 구현했습니다.

추가 및 수정된 파일은 아래와 같습니다. 
- URLConstant.swift 에 쏘카/그린카 링크 추가 
- DetailViewController.swift 에서 로직을 구현 